### PR TITLE
Overwrite GAMEMODE.OnDamagedByExplosion

### DIFF
--- a/lua/autorun/server/disable_explosion_ringing.lua
+++ b/lua/autorun/server/disable_explosion_ringing.lua
@@ -1,3 +1,7 @@
-GAMEMODE.OnDamagedByExplosion = function()
-    -- no ringing
+local function afterGamemodeLoaded()
+    GAMEMODE.OnDamagedByExplosion = function()
+        -- no ringing
+    end
 end
+hook.Remove( "PostGamemodeLoaded", "CFC_RestrictExplosionRinging" )
+hook.Add( "PostGamemodeLoaded", "CFC_RestrictExplosionRinging", afterGamemodeLoaded )

--- a/lua/autorun/server/disable_explosion_ringing.lua
+++ b/lua/autorun/server/disable_explosion_ringing.lua
@@ -1,0 +1,3 @@
+GAMEMODE.OnDamagedByExplosion = function()
+    -- no ringing
+end


### PR DESCRIPTION
overwrites the default OnDamagedByExplosion function
```lua
function GM:OnDamagedByExplosion( ply, dmginfo )
	ply:SetDSP( 35, false )
end
```
with an empty function removing the 💥 ringing